### PR TITLE
Fix problem importing bulma mixins

### DIFF
--- a/sass/bulma-list.scss
+++ b/sass/bulma-list.scss
@@ -1,4 +1,4 @@
-@use "node_modules/bulma/sass/utilities/mixins" as mixins;
+@use "bulma/sass/utilities/mixins" as mixins;
 
 @mixin has-mouse-pointer {
   @media (hover: hover) {


### PR DESCRIPTION
Use relative path so it's resolved by the SASS compiler.

I think this solves https://github.com/bluefantail/bulma-list/issues/23 issue. It works for me, although I can't assure it works in all settings.